### PR TITLE
Fix `redis.createClient` call arguments

### DIFF
--- a/lib/primus-redis-rooms.js
+++ b/lib/primus-redis-rooms.js
@@ -17,7 +17,7 @@ var PrimusRedisRooms = module.exports = function (primus, options) {
       );
     }
 
-    return redis.createClient(self.options.redis);
+    return redis.createClient(self.options.redis.port, self.options.redis.host, self.options.redis.options);
   }
 
   channel = options.redis.channel || 'primus';


### PR DESCRIPTION
The current implementation using `return redis.createClient(self.options.redis)` does not conform with the `createClient` method signature from redis, this pull request fixes that...
